### PR TITLE
FIXED is_essential default value set to false

### DIFF
--- a/pages/pantries/[id].tsx
+++ b/pages/pantries/[id].tsx
@@ -158,7 +158,7 @@ export default function Pantry() {
 
   const { description, title } = pantry;
   function addProducts() {
-    setCurrentProduct(() => ({ 'pantry_id': pantry.id }));
+    setCurrentProduct(() => ({ 'pantry_id': pantry.id, "is_essential": false }));
     setIsAddingProducts(true);
   }
 


### PR DESCRIPTION
Default value for `is_essnetial` was set to `null`. User needed to select and unselect "is essential"  for the value to be `false`. Would not save b/c db constraints don't allow null. Default value is now set to `false`