### PR TITLE
strcitly typed AlertComponents

### DIFF
--- a/components/AlertComponents.tsx
+++ b/components/AlertComponents.tsx
@@ -1,6 +1,15 @@
 /* This example requires Tailwind CSS v2.0+ */
 
-export function AlertFormList( { errorMessages }) {
+type ErrorMessage = {
+  message: string;
+  code: string;
+}
+
+type Alerts = {
+  errorMessages: ErrorMessage[];
+}
+
+export function AlertFormList( { errorMessages }: Alerts) {
   return (
     <div className="rounded-md bg-red-50 p-4">
       <div className="flex">
@@ -8,7 +17,7 @@ export function AlertFormList( { errorMessages }) {
           <h3 className="text-sm font-medium text-red-800">There was an error with your submission</h3>
           <div className="mt-2 text-sm text-red-700">
             <ul role="list" className="list-disc space-y-1 pl-5">
-              {errorMessages.map(error => <li key={error.code}>{error.message}</li>)}
+              {errorMessages.map((error, i) => <li key={i}>{error.message}</li>)}
             </ul>
           </div>
         </div>


### PR DESCRIPTION
-Alert Component is now strictly typed.

-Removed error `code` property from ErrorMessage type.

-Using index as `key` for each message instead of `error.code`
