### PR TITLE
Do not ignore TS error in production builds

### DIFF
--- a/components/ProductEditor.tsx
+++ b/components/ProductEditor.tsx
@@ -49,7 +49,7 @@ export default function ProductEditor({
     </option>
   ));
 
-  function onProductChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+  function onProductChange(e) {
     // for boolean product attributes use "checked" property of input instead of "value" so that the value is boolean and not string
     let value: string | boolean | null = null;
     if (e.target instanceof HTMLInputElement && e.target.type === 'checkbox') {

--- a/components/ProductEditor.tsx
+++ b/components/ProductEditor.tsx
@@ -49,7 +49,7 @@ export default function ProductEditor({
     </option>
   ));
 
-  function onProductChange(e) {
+  function onProductChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
     // for boolean product attributes use "checked" property of input instead of "value" so that the value is boolean and not string
     let value: string | boolean | null = null;
     if (e.target instanceof HTMLInputElement && e.target.type === 'checkbox') {

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  typescript: {
-    // !! WARN !!
-    // Dangerously allow production builds to successfully complete even if
-    // your project has type errors.
-    // !! WARN !!
-    ignoreBuildErrors: true
-  }
+  reactStrictMode: true
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Removed configuration parameter from Next.js config that ignored TypeScript errors now that the project is fully free of errors.

Note: added an error for testing purposes to demonstrate that the build does not pass with errors